### PR TITLE
Add docker logs to the makefile build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
 build-from-deps:
 	docker compose -f docker/build-sm64-from-deps/docker-compose.yaml up --build -d
+	@docker logs -f sm64-deps


### PR DESCRIPTION
## Changed
- add docker logs to the build makefile target for automatic printing of the build stages