### PR TITLE
Move download_dependencies.sh to Makefile target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+## Ignore upstream dependencies being refactored
 deps/*
+
+## Ignore user-provided assets
+baserom/*

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
 build-from-deps:
 	docker compose -f docker/build-sm64-from-deps/docker-compose.yaml up --build -d
 	@docker logs -f sm64-deps
+
+download-deps:
+	@mkdir -p deps/sm64
+	git clone https://github.com/n64decomp/sm64.git deps/sm64
+	@echo "Copying over base rom..."
+	@cp baserom/baserom.us.z64 deps/sm64/baserom.us.z64
+	@echo "All set up!"
+
+clean-deps:
+	$(RM) -r deps

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,24 @@
+DEPS_DIR := deps/sm64
+
+BASEROM_SOURCE := baserom/baserom.us.z64
+BASEROM_TARGET := $(DEPS_DIR)/baserom.us.z64
+
+BUILD_FROM_DEPS_DOCKER_COMPOSE := docker compose -f docker/build-sm64-from-deps/docker-compose.yaml
+
 default: build-from-deps
 
 build-from-deps:
-	docker compose -f docker/build-sm64-from-deps/docker-compose.yaml up --build -d
+	@echo "Copying over base rom..."
+	@cp $(BASEROM_SOURCE) $(BASEROM_TARGET)
+	$(BUILD_FROM_DEPS_DOCKER_COMPOSE) up --build -d
 	@docker logs -f sm64-deps
 
-download-deps:
+download-deps: clean-deps
 	@mkdir -p deps/sm64
-	git clone https://github.com/n64decomp/sm64.git deps/sm64
-	@echo "Copying over base rom..."
-	@cp baserom/baserom.us.z64 deps/sm64/baserom.us.z64
-	@echo "All set up!"
+	git clone https://github.com/n64decomp/sm64.git $(DEPS_DIR)
 
 clean-deps:
-	$(RM) -r deps
+	@echo "Removing any existing build artifacts..."
+	@$(BUILD_FROM_DEPS_DOCKER_COMPOSE) run --rm sm64-deps rm -rf /sm64/*
+	@echo "Removing previously downloaded dependencies..."
+	@$(RM) -r deps/sm64

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+default: build-from-deps
+
 build-from-deps:
 	docker compose -f docker/build-sm64-from-deps/docker-compose.yaml up --build -d
 	@docker logs -f sm64-deps

--- a/README.md
+++ b/README.md
@@ -4,4 +4,24 @@ A long-term refactoring exercise from ASM/C to modern C++ on an embedded platfor
 
 ## Getting started
 
-This repo has external dependencies that are not provided as part of this coding exercise.  The shell script `download_dependencies.sh` will pull in the required dependencies assuming that .git is installed.
+This repo has external dependencies that are not provided as part of this coding exercise.
+
+### Your sm64 reference ROM
+
+The assets required to compile a working sm64 ROM are not provided as part of this refactoring.  A working sm64 ROM (currently US only) must be provided at `baserom/baserom.us.z64` for compilation to succeed.
+
+### The reference code
+
+The following make target will bring in the required dependencies under the `deps/` directory.
+
+```bash
+make download-deps
+```
+
+## Building the ROM
+
+The following make target utilizes docker for the compilation environment.
+
+```bash
+make build-from-deps
+```

--- a/download_dependencies.sh
+++ b/download_dependencies.sh
@@ -1,5 +1,0 @@
-#! /bin/bash
-
-# Pull in the decomp reference code
-mkdir -p deps/sm64
-git clone https://github.com/n64decomp/sm64.git deps/sm64


### PR DESCRIPTION
## Description

Before I had custom Makefile targets to orchestrate docker compilation, the `download_dependencies.sh` script was all that was needed to jump into this repo.  Now, all actions are through the Makefile, including downloading the dependencies, copying the user-provided assets, and necessary docker commands.

## Changed
- Added `make download-deps` to pull in the upstream repo (reference) code
- Added asset copying from an untracked directory to `make build-from-deps`
- Updated the README to reflect the current usage for this repo